### PR TITLE
Fixing pagination

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -52,7 +52,7 @@
               {{ content }}
 							{% endif %}
 
-              {% for post in site.posts %}
+              {% for post in paginator.posts %}
               <!-- blogpost start -->
 							<article class="blogpost">
 								<header>


### PR DESCRIPTION
Currently the site is showing too many posts per page... This should fix that.

Number of posts per page is controlled by the `paginate:` setting in `_config.yml` (currently set to 5)