### PR TITLE
YouTube embeds

### DIFF
--- a/_includes/youtube.html
+++ b/_includes/youtube.html
@@ -1,0 +1,4 @@
+<div class="youtube">
+    <iframe src="https://www.youtube.com/embed/{{include.videoid}}?rel=0" frameborder="0" allow="autoplay; encrypted-media"
+        allowfullscreen></iframe>
+</div>

--- a/css/custom.css
+++ b/css/custom.css
@@ -38,3 +38,20 @@ header.header {
     float: right;
   }
 }
+
+/* YouTube sizing */
+div.youtube {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-bottom: 56.25%;
+  text-align: center;
+}
+div.youtube iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+/* End YouTube sizing */


### PR DESCRIPTION
Adding an include for YouTube videos plus styles to ensure a width and height (in 16:9 aspect ratio) that doesn't break on small screen sizes

Use include like this:
`{% include youtube.html videoid="<video ID here>" %}`